### PR TITLE
Consume instanceid from rabbitmq

### DIFF
--- a/src/main/java/io/github/innobridge/statemachine/Application.java
+++ b/src/main/java/io/github/innobridge/statemachine/Application.java
@@ -8,7 +8,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
     io.github.innobridge.statemachine.controller.ApplicationSpecificSpringComponentScanMarker.class,
     io.github.innobridge.statemachine.service.ApplicationSpecificSpringComponentScanMarker.class,
     io.github.innobridge.statemachine.repository.ApplicationSpecificSpringComponentScanMarker.class,
-    io.github.innobridge.statemachine.publisher.ApplicationSpecificSpringComponentScanMarker.class
+    io.github.innobridge.statemachine.publisher.ApplicationSpecificSpringComponentScanMarker.class,
+    io.github.innobridge.statemachine.consumer.ApplicationSpecificSpringComponentScanMarker.class
 })
 public class Application {
 

--- a/src/main/java/io/github/innobridge/statemachine/consumer/ApplicationSpecificSpringComponentScanMarker.java
+++ b/src/main/java/io/github/innobridge/statemachine/consumer/ApplicationSpecificSpringComponentScanMarker.java
@@ -1,0 +1,5 @@
+package io.github.innobridge.statemachine.consumer;
+
+public interface ApplicationSpecificSpringComponentScanMarker {   
+    
+}

--- a/src/main/java/io/github/innobridge/statemachine/consumer/RabbitMQConsumer.java
+++ b/src/main/java/io/github/innobridge/statemachine/consumer/RabbitMQConsumer.java
@@ -1,0 +1,24 @@
+package io.github.innobridge.statemachine.consumer;
+
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.QUEUE_NAME;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import io.github.innobridge.statemachine.service.StateMachineService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class RabbitMQConsumer {
+    
+    @Autowired
+    private StateMachineService stateMachineService;
+
+    @RabbitListener(queues = {QUEUE_NAME})
+    public void consumeMessage(String message) {
+        log.info("Received message: " + message);
+        stateMachineService.processStateMachine(message);
+    }
+}


### PR DESCRIPTION
Implement the consumer for rabbitmq that consumes the instanceid.

For nonblocking states, we process the next state without stopping or external triggers. So if the next state is nonblocking, the instanceid(statemachine instance) is sent to rabbitmq, and update the executionthread with the next state. The consumer will pull the instanceid from the queue and execute the next state indicated in the executionthread.

New consumer component:

* [`src/main/java/io/github/innobridge/statemachine/consumer/RabbitMQConsumer.java`](diffhunk://#diff-90f1b0fed34faca8dd8487800ff05929a55d70a19fc05c4322846cdfabd2786dR1-R24): Implemented the `RabbitMQConsumer` class to listen for messages on the specified queue and process them using the `StateMachineService`.