### PR TITLE
add logic to not block when the list of child instances is empty

### DIFF
--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractChildState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractChildState.java
@@ -40,7 +40,9 @@ public abstract class AbstractChildState extends AbstractState implements ChildS
         if (!isDispatched()) {
             setChildIds(dispatch(stateMachineService));
             setDispatched(true);
-            setBlocking(true);
+            if (!childIds.isEmpty()) {
+                setBlocking(true);
+            }
             return this;
         }
         if (completedChildInstances(childIds, executionThreadRepository)) {


### PR DESCRIPTION
This pull request includes a small but important change to the `AbstractChildState` class to handle state transitions more accurately by ensuring that the state is marked as blocking when child IDs are dispatched.

* [`src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractChildState.java`](diffhunk://#diff-c0be93cde405196206f3c86d162ecdd56f0a6ae7af3bd705399143e3d4b10a10R43-R45): Added a condition to set the state as blocking if `childIds` is not empty after dispatching.