### PR TITLE
Logging State in History Collection

### DIFF
--- a/src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java
+++ b/src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java
@@ -1,6 +1,7 @@
 package io.github.innobridge.statemachine.configuration;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -14,9 +15,15 @@ public class RepositoryConfig {
     @Autowired
     private MongoClient mongoClient;
 
+    @Value("${statemachine.history.enabled:true}")
+    private boolean historyEnabled;
+
     @Bean
     public MongoTemplate mongoTemplate() {
         return new MongoTemplate(mongoClient, STATE_MACHINE);
     }
- 
+
+    public boolean isHistoryEnabled() {
+        return historyEnabled;
+    }
 }

--- a/src/main/java/io/github/innobridge/statemachine/service/StateMachineService.java
+++ b/src/main/java/io/github/innobridge/statemachine/service/StateMachineService.java
@@ -1,9 +1,7 @@
 package io.github.innobridge.statemachine.service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=Application
+
+statemachine.history.enabled=true


### PR DESCRIPTION
This pull request introduces several important changes to the state machine application, including the addition of a new event listener, configuration updates, and error handling improvements. Below is a summary of the key changes:

### Configuration Updates:
* Added a new configuration property `statemachine.history.enabled` to enable or disable history tracking (`src/main/resources/application.properties`, `src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java`) [[1]](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cR4) [[2]](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cR18-R28) [[3]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R2-R3).

### Event Listener:
* Introduced `StateChangeListener` class to handle state change events and store history copies of state changes when history tracking is enabled (`src/main/java/io/github/innobridge/statemachine/listener/StateChangeListener.java`).

### Error Handling:
* Enhanced error handling in `RabbitMQConsumer` to log errors without rethrowing exceptions for `IllegalStateException` and `DuplicateKeyException`, preventing message requeuing (`src/main/java/io/github/innobridge/statemachine/consumer/RabbitMQConsumer.java`) [[1]](diffhunk://#diff-90f1b0fed34faca8dd8487800ff05929a55d70a19fc05c4322846cdfabd2786dR9-R10) [[2]](diffhunk://#diff-90f1b0fed34faca8dd8487800ff05929a55d70a19fc05c4322846cdfabd2786dR24-R29).

### Dependency Management:
* Added necessary imports for new features and error handling in relevant classes (`src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java`, `src/main/java/io/github/innobridge/statemachine/consumer/RabbitMQConsumer.java`, `src/main/java/io/github/innobridge/statemachine/service/StateMachineService.java`) [[1]](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cR4) [[2]](diffhunk://#diff-90f1b0fed34faca8dd8487800ff05929a55d70a19fc05c4322846cdfabd2786dR9-R10) [[3]](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544L4-L6).