### PR TITLE
Add Visibility service to get information about active instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>io.github.innobridge</groupId>
 	<artifactId>statemachine</artifactId>
-	<version>0.0.1</version>
+	<version>0.0.2</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Library for creating distributed state machines</description>
     <url>https://github.com/innoBridge/StateMachine</url>

--- a/src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java
+++ b/src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java
@@ -1,5 +1,7 @@
 package io.github.innobridge.statemachine.configuration;
 
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATE_MACHINE;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +12,6 @@ import com.mongodb.client.MongoClient;
 
 @Configuration
 public class RepositoryConfig {
-    public static final String STATE_MACHINE = "StateMachine";
 
     @Autowired
     private MongoClient mongoClient;

--- a/src/main/java/io/github/innobridge/statemachine/constants/StateMachineConstant.java
+++ b/src/main/java/io/github/innobridge/statemachine/constants/StateMachineConstant.java
@@ -1,7 +1,15 @@
 package io.github.innobridge.statemachine.constants;
 
 public class StateMachineConstant {
+    // RabbitMQ
     public static final String QUEUE_NAME = "state_machine";
     public static final String EXCHANGE_NAME = "state_machine_exchange";
     public static final String ROUTING_KEY = "state_machine_routing_key";
+
+    // Database
+    public static final String STATE_MACHINE = "StateMachine";
+    public static final String STATE_MACHINE_INSTANCE = "StateMachineInstance";
+    public static final String EXECUTION_THREAD = "ExecutionThread";
+    public static final String STATES = "States";
+    public static final String HISTORY = "History";
 }

--- a/src/main/java/io/github/innobridge/statemachine/listener/StateChangeListener.java
+++ b/src/main/java/io/github/innobridge/statemachine/listener/StateChangeListener.java
@@ -1,5 +1,7 @@
 package io.github.innobridge.statemachine.listener;
 
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.HISTORY;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -33,7 +35,7 @@ public class StateChangeListener extends AbstractMongoEventListener<AbstractStat
         }
 
         String collectionName = ((MongoMappingEvent<?>) event).getCollectionName();
-        if ("History".equals(collectionName)) {
+        if (HISTORY.equals(collectionName)) {
             return; // Skip if this is already a history state
         }
         
@@ -57,6 +59,6 @@ public class StateChangeListener extends AbstractMongoEventListener<AbstractStat
             }
         };
         historyCopy.setInstanceId(state.getInstanceId());
-        mongoTemplate.insert(historyCopy, "History");
+        mongoTemplate.insert(historyCopy, HISTORY);
     }
 }

--- a/src/main/java/io/github/innobridge/statemachine/service/VisibilityService.java
+++ b/src/main/java/io/github/innobridge/statemachine/service/VisibilityService.java
@@ -1,0 +1,43 @@
+package io.github.innobridge.statemachine.service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.innobridge.statemachine.repository.ExecutionThreadRepository;
+import io.github.innobridge.statemachine.repository.StateRepository;
+import io.github.innobridge.statemachine.state.definition.ExecutionThread;
+
+@Service
+public class VisibilityService {
+    
+    @Autowired
+    private ExecutionThreadRepository executionThreadRepository;
+
+    @Autowired
+    private StateRepository stateRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public Set<String> getActiveInstances() {
+        return executionThreadRepository.findAll().stream()
+                .map(ExecutionThread::getId)
+                .collect(Collectors.toSet());
+    }
+
+    public ExecutionThread getExecutionThread(String instanceId) {
+        return executionThreadRepository.findById(instanceId).get();
+    }
+
+    public Set<JsonNode> getStates(String instanceId) {
+        return stateRepository.findByInstanceId(instanceId).stream()
+                .map(state -> (JsonNode) objectMapper.valueToTree(state))
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/io/github/innobridge/statemachine/state/definition/ExecutionThread.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/definition/ExecutionThread.java
@@ -7,7 +7,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.Data;
 
-@Document(collection = "StateMachineInstance")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATE_MACHINE_INSTANCE;
+
+@Document(collection = STATE_MACHINE_INSTANCE)
 @Data
 public class ExecutionThread {
 

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractBlockingTransitionState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractBlockingTransitionState.java
@@ -11,7 +11,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractBlockingTransitionState extends AbstractState implements BlockingTransitionState {
 
 

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractChildState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractChildState.java
@@ -15,7 +15,9 @@ import io.github.innobridge.statemachine.service.StateMachineService;
 import io.github.innobridge.statemachine.state.definition.ChildState;
 import io.github.innobridge.statemachine.state.definition.State;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractChildState extends AbstractState implements ChildState {
     private boolean dispatched = false;
     private boolean blocking = false;
@@ -36,7 +38,6 @@ public abstract class AbstractChildState extends AbstractState implements ChildS
 
     @Override
     public State processing(Map<String, Function<State, State>> transitions, Optional<JsonNode> input, ExecutionThreadRepository executionThreadRepository, StateMachineService stateMachineService) {
-        System.out.println("isDispatched: " + isDispatched());
         if (!isDispatched()) {
             setChildIds(dispatch(stateMachineService));
             setDispatched(true);

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractInitialState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractInitialState.java
@@ -13,7 +13,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractInitialState extends AbstractState implements InitialState {
 
     public Map<State, Function<State, State>> transitions;

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractNonBlockingTransitionState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractNonBlockingTransitionState.java
@@ -3,7 +3,9 @@ package io.github.innobridge.statemachine.state.implementation;
 import io.github.innobridge.statemachine.state.definition.NonBlockingTransitionState;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractNonBlockingTransitionState extends AbstractBlockingTransitionState implements NonBlockingTransitionState {
 
     @Override

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractState.java
@@ -11,7 +11,9 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractState implements State {
     @Id
     private String id;

--- a/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractTerminalState.java
+++ b/src/main/java/io/github/innobridge/statemachine/state/implementation/AbstractTerminalState.java
@@ -8,7 +8,9 @@ import java.util.function.Function;
 
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "States")
+import static io.github.innobridge.statemachine.constants.StateMachineConstant.STATES;
+
+@Document(collection = STATES)
 public abstract class AbstractTerminalState extends AbstractState implements TerminalState {
  
     @Override


### PR DESCRIPTION
This pull request includes several changes aimed at improving code consistency, enhancing logging, and refactoring the state management constants. The most important changes include updating the version in `pom.xml`, centralizing constants, enhancing logging in `StateMachineService`, and introducing a new `VisibilityService` class.

### Version Update:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L13-R13): Updated the project version from `0.0.1` to `0.0.2`.

### Centralizing Constants:
* [`src/main/java/io/github/innobridge/statemachine/constants/StateMachineConstant.java`](diffhunk://#diff-b79e68e7290f82d4daf52171f670da719a5a45f1aa9c8643a61dd67ef186582cR4-R14): Added new constants for database collections and moved the `STATE_MACHINE` constant here.
* [`src/main/java/io/github/innobridge/statemachine/configuration/RepositoryConfig.java`](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cR3-R4): Removed the `STATE_MACHINE` constant and used the one from `StateMachineConstant`. [[1]](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cR3-R4) [[2]](diffhunk://#diff-99218d5e8736c1e1bb6d29d4148b7dab4da5fd023fd2799eecea19822e1e531cL13)
* Updated various classes to use centralized constants for database collections:
  * `StateChangeListener.java` [[1]](diffhunk://#diff-edb4898f7510f93e8516903eade6b00ff458f56ce06b0f6d048acdc9f17756d3R3-R4) [[2]](diffhunk://#diff-edb4898f7510f93e8516903eade6b00ff458f56ce06b0f6d048acdc9f17756d3L36-R38) [[3]](diffhunk://#diff-edb4898f7510f93e8516903eade6b00ff458f56ce06b0f6d048acdc9f17756d3L60-R62)
  * `ExecutionThread.java`
  * `AbstractBlockingTransitionState.java`
  * `AbstractChildState.java`
  * `AbstractInitialState.java`
  * `AbstractNonBlockingTransitionState.java`
  * `AbstractState.java`
  * `AbstractTerminalState.java`

### Enhanced Logging:
* [`src/main/java/io/github/innobridge/statemachine/service/StateMachineService.java`](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544R21-R23): Replaced `System.out.println` statements with `log.info` and `log.debug` for better logging and debugging. [[1]](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544R21-R23) [[2]](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544L37-R47) [[3]](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544L72-R75) [[4]](diffhunk://#diff-852799f78a499447292490b3c78bfec8e801ddd1a6cbefd598867bd0ca868544R96)

### New Service Class:
* [`src/main/java/io/github/innobridge/statemachine/service/VisibilityService.java`](diffhunk://#diff-0227c2fa88063c11c98c31a08c60acf764b8df04d566b889c64987e36a916c07R1-R43): Introduced a new service class to manage visibility-related operations, including fetching active instances and states.

These changes collectively improve the maintainability and readability of the codebase, while also enhancing logging capabilities for better monitoring and debugging.